### PR TITLE
Removed 'discord.py>=2.0.0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 A library to implement a leveling system into a discord bot. One of the most popular discord bots out there is MEE6 and it's leveling system. This library provides ways to easily implement one for yourself. It uses SQLite (aiosqlite) to locally query things such as their XP, rank, and level. Various amounts of other methods and classes are also provided so you can access or remove contents from the database file.
 
 ## Installing
-You can install the latest [PyPI version](https://pypi.org/project/discordLevelingSystem/) of the library by doing:
+You can install the latest version of the library by doing:
 
-`$ pip install discordLevelingSystem`
-
-Or the development version:
-
-`$ pip install git+https://github.com/Defxult/discordLevelingSystem`
+`$ pip install git+https://github.com/Paillat-dev/discordLevelingSystem`
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
     license='MIT',
     keywords=tags,
     packages=find_packages(),
-    install_requires=['aiosqlite>=0.17.0', 'discord.py>=2.0.0', 'Pillow>=9.2.0']
+    install_requires=['aiosqlite>=0.17.0', 'Pillow>=9.2.0']
 )


### PR DESCRIPTION
Removed 'discord.py>=2.0.0' in order to be able to use forks of 'discord.py>=2.0.0', which we install separately and not have to uninstall discord.py each time, which conflicts with some of them.